### PR TITLE
Correct British spelling of 'licence'

### DIFF
--- a/doclicense/doclicense-UKenglish.ldf
+++ b/doclicense/doclicense-UKenglish.ldf
@@ -1,3 +1,3 @@
 \ProvidesFile{doclicense-UKenglish.ldf}
 
-\input{doclicense-english.ldf}
+\input{doclicense-british.ldf}

--- a/doclicense/doclicense-british.ldf
+++ b/doclicense/doclicense-british.ldf
@@ -1,3 +1,4 @@
 \ProvidesFile{doclicense-british.ldf}
 
 \input{doclicense-english.ldf}
+\@namedef{doclicense@lang@word@license}{ licence}%


### PR DESCRIPTION
In British English, the noun is spelled 'licence'; 'license' is however used for the verb.