### PR TITLE
[doclicense] Add the missing 'ND' part of french by-nc-nd name

### DIFF
--- a/doclicense/doclicense-french.ldf
+++ b/doclicense/doclicense-french.ldf
@@ -25,4 +25,4 @@
 \@namedef{doclicense@lang@lic@CC@by-nd@4.0}{Attribution - Pas de modification 4.0 International}%
 \@namedef{doclicense@lang@lic@CC@by-nc@4.0}{Attribution - Pas d'utilisation commerciale 4.0 International}%
 \@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{Attribution - Pas d'utilisation commerciale - Partage dans les m\^emes conditions 4.0 International}%
-\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Attribution - Pas d'utilisation commerciale 4.0 International}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Attribution - Pas d'utilisation commerciale - Pas de modification 4.0 International}%


### PR DESCRIPTION
The french definition of doclicense@lang@lic@CC@by-nc-nd@4.0 was missing the 'ND' part