### PR TITLE
Image position parameter for doclicenseThis

### DIFF
--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -221,6 +221,9 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 %   \item[Spanish] Added by \href{https://github.com/elsudano}{Carlos}.
 % \end{eqlist}
 %
+% Image position for \cmd{\doclicenseThis}: right (default) or left.
+% \DescribePara{imageposition}
+%
 % Default image width for the license image.
 % \DescribePara{imagewidth}
 %
@@ -462,6 +465,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \DeclareStringOption{version}
 \DeclareStringOption{lang}
 \DeclareStringOption{imagemodifier}
+\DeclareStringOption[right]{imageposition}
 \DeclareStringOption[10em]{imagewidth}
 \DeclareStringOption{hyphenation}
 %% )))
@@ -585,25 +589,40 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \newcommand{\doclicenseLicense}{\doclicenseThis} %% legacy support
 \newcommand{\doclicenseThis}{%
   \setlength{\doclicense@hsize}{\textwidth-\doclicense@imagewidth-2em}%
+  \ifthenelse{\equal{\doclicense@imageposition}{left}}{%
+    \begin{center}
+      \begin{minipage}{\doclicense@imagewidth}
+        \doclicenseImage%
+      \end{minipage}
+      \hfill
+      \begin{minipage}{\doclicense@hsize}
+        \ifthenelse{\isempty{\doclicense@hyphenation}}{}{%
+          \@nameuse{\doclicense@hyphenation}%
+        }%
+        \doclicenseLongText%
+      \end{minipage}
+    \end{center}
+  }{%
   % \ifthenelse{\isnamedefined{iflandscape}}{%
   %   \iflandscape{%
   %     \setlength{\doclicense@hsize}{\doclicense@hsize-10em}%
   %   }{}%
   % }{}%
   % {%
-  \begin{center}
-    \begin{minipage}{\doclicense@hsize}
-      \ifthenelse{\isempty{\doclicense@hyphenation}}{}{%
-        \@nameuse{\doclicense@hyphenation}%
-      }%
-      \doclicenseLongText%
-    \end{minipage}
-    \hfill
-    \begin{minipage}{\doclicense@imagewidth}
-      \doclicenseImage%
-    \end{minipage}
-  \end{center}
+    \begin{center}
+      \begin{minipage}{\doclicense@hsize}
+        \ifthenelse{\isempty{\doclicense@hyphenation}}{}{%
+          \@nameuse{\doclicense@hyphenation}%
+        }%
+        \doclicenseLongText%
+      \end{minipage}
+      \hfill
+      \begin{minipage}{\doclicense@imagewidth}
+        \doclicenseImage%
+      \end{minipage}
+    \end{center}
   % }
+  }
 }
 %% )))
 


### PR DESCRIPTION
A new package option to display image at text's left (inverted order).
Default behaviour is the same, text and then image.
Space between elements is reduced to 1em.

Please let me know if there is a smarter way to do that.