### PR TITLE
Update spanish translation

### DIFF
--- a/doclicense/doclicense-spanish.ldf
+++ b/doclicense/doclicense-spanish.ldf
@@ -1,6 +1,6 @@
 \ProvidesFile{doclicense-spanish.ldf}
 
-\@namedef{doclicense@lang@thisDoc}{Este documento esta realizado bajo licencia}%
+\@namedef{doclicense@lang@thisDoc}{Esta obra está bajo una licencia}%
 \@namedef{doclicense@lang@word@license}{}%
 
 \@namedef{doclicense@lang@lic@CC@code}{es}%


### PR DESCRIPTION
Old translation had a spelling mistake ("esta" instead of "está"). My proposed version uses the same phrasing as in https://creativecommons.org/choose/?lang=es

Which closely matches the English version.