### PR TITLE
Two small fixes

### DIFF
--- a/doclicense/doclicense-italian.ldf
+++ b/doclicense/doclicense-italian.ldf
@@ -1,6 +1,6 @@
 \ProvidesFile{doclicense-italian.ldf}
 
-\@namedef{doclicense@lang@thisDoc}{Quest'opera è distribuita con Licenza}%
+\@namedef{doclicense@lang@thisDoc}{Quest'opera è distribuita con licenza}%
 \@namedef{doclicense@lang@word@license}{}%
 \ifthenelse{\equal{\doclicense@imagemodifier}{}}{%
   \@namedef{doclicense@imagemodifier}{-eu}

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -561,7 +561,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \newcommand{\doclicenseLongNameRef}{\href{\doclicenseURL}{\doclicenseLongName}}
 \newcommand{\doclicenseText}{%
   \doclicense@lang@thisDoc\space
-  \href{\doclicenseURL}{\enquote{\doclicenseName{}}}
+  \href{\doclicenseURL}{\enquote{\doclicenseName{}}}%
   \doclicense@lang@word@license.\xspace%
 }
 \newcommand{\doclicenseLongText}{%

--- a/doclicense/doclicense.sty
+++ b/doclicense/doclicense.sty
@@ -88,7 +88,7 @@
 \newcommand{\doclicenseLongNameRef}{\href{\doclicenseURL}{\doclicenseLongName}}
 \newcommand{\doclicenseText}{%
   \doclicense@lang@thisDoc\space
-  \href{\doclicenseURL}{\enquote{\doclicenseName{}}}
+  \href{\doclicenseURL}{\enquote{\doclicenseName{}}}%
   \doclicense@lang@word@license.\xspace%
 }
 \newcommand{\doclicenseLongText}{%


### PR DESCRIPTION
- An unescaped newline caused two spaces between license name and 'license' word (or the dot, for languages where the word comes before the license name) when using `\doclicenseText`.
- The capital L is not necessary for Italian language (the official text from CC site is also lowercase).