### PR TITLE
Add support for Dutch documents with doclicense

### DIFF
--- a/doclicense/doclicense-dutch.ldf
+++ b/doclicense/doclicense-dutch.ldf
@@ -1,0 +1,27 @@
+\ProvidesFile{doclicense-dutch.ldf}
+
+\@namedef{doclicense@lang@thisDoc}{Dit werk valt onder een}%
+\@namedef{doclicense@lang@word@license}{-licentie}%
+\ifthenelse{\equal{\doclicense@imagemodifier}{}}{%
+  \@namedef{doclicense@imagemodifier}{-eu}
+}{}
+
+\@namedef{doclicense@lang@lic@CC@code}{nl}%
+%% Using: https://en.wikipedia.org/wiki/ISO_639-1
+
+\@namedef{doclicense@lang@lic@CC@zero@1.0}{CC0 1.0 Universeel}%
+\@namedef{doclicense@lang@lic@CC@pd@1.0}{Copyright-Only Dedication}% Based on US right. Use Zero in no-US countries.
+
+\@namedef{doclicense@lang@lic@CC@by@3.0}{Naamsvermelding 3.0 Nederland}%
+\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{Naamsvermelding-GelijkDelen 3.0 Nederland}%
+\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{Naamsvermelding-GeenAfgeleideWerken 3.0 Nederland}%
+\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{Naamsvermelding-NietCommercieel 3.0 Nederland}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{Naamsvermelding-NietCommercieel-GelijkDelen 3.0 Nederland}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{Naamsvermelding-NietCommercieel-GeenAfgeleideWerken 3.0 Nederland}%
+
+\@namedef{doclicense@lang@lic@CC@by@4.0}{Naamsvermelding 4.0 Internationaal}%
+\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{Naamsvermelding-GelijkDelen 4.0 Internationaal}%
+\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{Naamsvermelding-GeenAfgeleideWerken 4.0 Internationaal}%
+\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{Naamsvermelding-NietCommercieel 4.0 Internationaal}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{Naamsvermelding-NietCommercieel-GelijkDelen 4.0 Internationaal}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Naamsvermelding-NietCommercieel-GeenAfgeleideWerken 4.0 Internationaal}%

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -218,6 +218,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 % Supported languages:
 % ^^A Sorted alphabetically.
 % \begin{eqlist}
+%   \item[Dutch]   Added by \href{https://github.com/pkok}{Patrick de Kok}.
 %   \item[English] Added by \href{https://github.com/ypid}{Robin Schneider}.
 %   \item[French]  Added by \href{https://github.com/ericguirbal}{\'Eric Guirbal}.
 %   \item[German]  Added by \href{https://github.com/ypid}{Robin Schneider}.
@@ -248,7 +249,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 %   |]{doclicense}|
 % \end{quote}
 %
-% Note that if French or German is set as language then \enquote{-eu} will be used as
+% Note that if Dutch, French, German or Italian is set as language then \enquote{-eu} will be used as
 % default for this option.
 %
 % Currently supported are \enquote{-eu} and \enquote{-us}.


### PR DESCRIPTION
Thank you for your work!

The terms are retrieved from the Dutch [Creative Commons license
picker](https://creativecommons.org/choose/?lang=nl#).