### PR TITLE
Do not use enumitem

### DIFF
--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -127,7 +127,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 % \changes{1.7.1}{2018/04/24}{Include .eps versions of the images to allow using `latex` with dvi output. Thanks to robertpetry for reporting.}
 % \changes{1.8.0}{2018/06/10}{Added Polish translation.}
 % \changes{1.9.0}{2019/04/07}{Added Catalan, Galician, Chinese and Portuguese translation. Detect and give hint when enquote macro is already defined. Fix LaTeX Error: Too deeply nested.}
-% \changes{1.10.0}{2019/XX/XX}{Update Chinese translation.}
+% \changes{1.10.0}{2019/XX/XX}{Update Chinese translation. Do not load enumitem with beamer and provide option to omit its loading.}
 %
 %% ^^A nag warned about the center environment and it really messes up spacing.
 %
@@ -268,6 +268,12 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 % in the minipage environment of \cmd{\doclicenseThis}.
 % That allows you to change the behaviour how \cmd{\doclicenseLongText} is
 % typeset. By default, this option is not enabled.
+%
+% This option allows you to decide whether or not the \PrintPackage{enumitem} package is loaded.
+% \DescribePara{enumitem}
+% The package is loaded by default in order to prevent nesting issues. It is not
+% loaded, though, with the \PrintPackage{beamer} class, since \PrintPackage{enumitem} and \PrintPackage{beamer} are incompatible.
+% If you use \PrintOptionF{enumitem=false}, the package won't be loaded in any case.
 %
 % One possible use case is to set the option to \enquote{RaggedRight}.
 % This will use the \cmd{\RaggedRight} macro provided by the
@@ -487,6 +493,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \DeclareStringOption[10em]{imagewidth}
 \DeclareStringOption[2em]{imagedistance}
 \DeclareStringOption{hyphenation}
+\DeclareBoolOption[true]{enumitem}
 %% )))
 
 %    \end{macrocode}
@@ -504,8 +511,12 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \RequirePackage{etoolbox} %% \ifcsdef
 \RequirePackage{xspace}
 \RequirePackage{verbatim}
-\RequirePackage{enumitem}
 
+%% Use enumitem only if the beamer class is not loaded,
+%% as beamer and enumitem are incompatible
+\@ifclassloaded{beamer}{\doclicense@enumitemfalse}{}
+\ifdoclicense@enumitem
+\RequirePackage{enumitem}
 %% \setlistdepth{4} seems not to be needed. Try without it to avoid changing global variables.
 %% Enumeration scheme was chosen to match the html page once.
 \newlist{doclicense@enumerate}{enumerate}{4}
@@ -513,6 +524,10 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \setlist[doclicense@enumerate,2]{label = (\arabic*)}
 \setlist[doclicense@enumerate,3]{label = (\Alph*)}
 \setlist[doclicense@enumerate,4]{label = (\roman*)}
+\else
+\let\doclicense@enumerate\enumerate
+\let\enddoclicense@enumerate\endenumerate
+\fi
 
 \ifthenelse{
   \equal{\doclicense@hyphenation}{}

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -269,12 +269,6 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 % That allows you to change the behaviour how \cmd{\doclicenseLongText} is
 % typeset. By default, this option is not enabled.
 %
-% This option allows you to decide whether or not the \PrintPackage{enumitem} package is loaded.
-% \DescribePara{enumitem}
-% The package is loaded by default in order to prevent nesting issues. It is not
-% loaded, though, with the \PrintPackage{beamer} class, since \PrintPackage{enumitem} and \PrintPackage{beamer} are incompatible.
-% If you use \PrintOptionF{enumitem=false}, the package won't be loaded in any case.
-%
 % One possible use case is to set the option to \enquote{RaggedRight}.
 % This will use the \cmd{\RaggedRight} macro provided by the
 % \PrintPackage{ragged2e} package\footnote{The \PrintPackage{ragged2e} package will be loaded when it is required.}) with the intention of limiting the number of
@@ -306,6 +300,13 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 %   |  hyphenation={raggedright},| \\
 %   |]{doclicense}|
 % \end{quote}
+%
+% This option allows you to decide whether or
+% \DescribePara{enumitem}
+% not the \PrintPackage{enumitem} package is loaded.
+% The package is loaded by default in order to prevent nesting issues. It is not
+% loaded, though, with the \PrintPackage{beamer} class, since \PrintPackage{enumitem} and \PrintPackage{beamer} are incompatible.
+% If you use \PrintOptionF{enumitem=false}, the package won't be loaded in any case.
 %
 % \section{Macros}
 % \DescribeMacro{\doclicenseType}

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -127,7 +127,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 % \changes{1.7.1}{2018/04/24}{Include .eps versions of the images to allow using `latex` with dvi output. Thanks to robertpetry for reporting.}
 % \changes{1.8.0}{2018/06/10}{Added Polish translation.}
 % \changes{1.9.0}{2019/04/07}{Added Catalan, Galician, Chinese and Portuguese translation. Detect and give hint when enquote macro is already defined. Fix LaTeX Error: Too deeply nested.}
-% \changes{1.10.0}{2019/XX/XX}{Update Chinese translation. Do not load enumitem with beamer and provide option to omit its loading.}
+% \changes{1.10.0}{2019/XX/XX}{Update Chinese translation. Do not use enumitem for list label customization (beamer compatibility).}
 %
 %% ^^A nag warned about the center environment and it really messes up spacing.
 %
@@ -300,13 +300,6 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 %   |  hyphenation={raggedright},| \\
 %   |]{doclicense}|
 % \end{quote}
-%
-% This option allows you to decide whether or
-% \DescribePara{enumitem}
-% not the \PrintPackage{enumitem} package is loaded.
-% The package is loaded by default in order to prevent nesting issues. It is not
-% loaded, though, with the \PrintPackage{beamer} class, since \PrintPackage{enumitem} and \PrintPackage{beamer} are incompatible.
-% If you use \PrintOptionF{enumitem=false}, the package won't be loaded in any case.
 %
 % \section{Macros}
 % \DescribeMacro{\doclicenseType}
@@ -494,7 +487,6 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \DeclareStringOption[10em]{imagewidth}
 \DeclareStringOption[2em]{imagedistance}
 \DeclareStringOption{hyphenation}
-\DeclareBoolOption[true]{enumitem}
 %% )))
 
 %    \end{macrocode}
@@ -512,28 +504,17 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \RequirePackage{etoolbox} %% \ifcsdef
 \RequirePackage{xspace}
 \RequirePackage{verbatim}
+%% )))
 
-%% Use enumitem only if the beamer class is not loaded,
-%% as beamer and enumitem are incompatible
-\@ifclassloaded{beamer}{\doclicense@enumitemfalse}{}
-\ifdoclicense@enumitem
-\RequirePackage{enumitem}
-%% \setlistdepth{4} seems not to be needed. Try without it to avoid changing global variables.
-%% Enumeration scheme was chosen to match the html page once.
-\newlist{doclicense@enumerate}{enumerate}{4}
-\setlist[doclicense@enumerate,1]{label = (\alph*)}
-\setlist[doclicense@enumerate,2]{label = (\arabic*)}
-\setlist[doclicense@enumerate,3]{label = (\Alph*)}
-\setlist[doclicense@enumerate,4]{label = (\roman*)}
-\else
+%% Custom enumerate list with adjusted labels
+%% that match the license text convetions
 \newenvironment{doclicense@enumerate}{%
-\begin{enumerate}
-\renewcommand{\labelenumi}{(\alph{enumi})}%
-\renewcommand{\labelenumii}{(\arabic{enumii})}%
-\renewcommand{\labelenumiii}{(\Alph{enumiii})}%
-\renewcommand{\labelenumiv}{(\roman{enumiv})}%
+  \begin{enumerate}
+    \renewcommand{\labelenumi}{(\alph{enumi})}%
+    \renewcommand{\labelenumii}{(\arabic{enumii})}%
+    \renewcommand{\labelenumiii}{(\Alph{enumiii})}%
+    \renewcommand{\labelenumiv}{(\roman{enumiv})}%
 }{\end{enumerate}}
-\fi
 
 \ifthenelse{
   \equal{\doclicense@hyphenation}{}

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -525,8 +525,13 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \filedate.}}
 \setlist[doclicense@enumerate,3]{label = (\Alph*)}
 \setlist[doclicense@enumerate,4]{label = (\roman*)}
 \else
-\let\doclicense@enumerate\enumerate
-\let\enddoclicense@enumerate\endenumerate
+\newenvironment{doclicense@enumerate}{%
+\begin{enumerate}
+\renewcommand{\labelenumi}{(\alph{enumi})}%
+\renewcommand{\labelenumii}{(\arabic{enumii})}%
+\renewcommand{\labelenumiii}{(\Alph{enumiii})}%
+\renewcommand{\labelenumiv}{(\roman{enumiv})}%
+}{\end{enumerate}}
 \fi
 
 \ifthenelse{

--- a/doclicense/doclicense.sty
+++ b/doclicense/doclicense.sty
@@ -15,7 +15,6 @@
 \DeclareStringOption[10em]{imagewidth}
 \DeclareStringOption[2em]{imagedistance}
 \DeclareStringOption{hyphenation}
-\DeclareBoolOption[true]{enumitem}
 %% )))
 
 \ProcessLocalKeyvalOptions*
@@ -25,28 +24,17 @@
 \RequirePackage{etoolbox} %% \ifcsdef
 \RequirePackage{xspace}
 \RequirePackage{verbatim}
+%% )))
 
-%% Use enumitem only if the beamer class is not loaded,
-%% as beamer and enumitem are incompatible
-\@ifclassloaded{beamer}{\doclicense@enumitemfalse}{}
-\ifdoclicense@enumitem
-\RequirePackage{enumitem}
-%% \setlistdepth{4} seems not to be needed. Try without it to avoid changing global variables.
-%% Enumeration scheme was chosen to match the html page once.
-\newlist{doclicense@enumerate}{enumerate}{4}
-\setlist[doclicense@enumerate,1]{label = (\alph*)}
-\setlist[doclicense@enumerate,2]{label = (\arabic*)}
-\setlist[doclicense@enumerate,3]{label = (\Alph*)}
-\setlist[doclicense@enumerate,4]{label = (\roman*)}
-\else
+%% Custom enumerate list with adjusted labels
+%% that match the license text convetions
 \newenvironment{doclicense@enumerate}{%
-\begin{enumerate}
-\renewcommand{\labelenumi}{(\alph{enumi})}%
-\renewcommand{\labelenumii}{(\arabic{enumii})}%
-\renewcommand{\labelenumiii}{(\Alph{enumiii})}%
-\renewcommand{\labelenumiv}{(\roman{enumiv})}%
+  \begin{enumerate}
+    \renewcommand{\labelenumi}{(\alph{enumi})}%
+    \renewcommand{\labelenumii}{(\arabic{enumii})}%
+    \renewcommand{\labelenumiii}{(\Alph{enumiii})}%
+    \renewcommand{\labelenumiv}{(\roman{enumiv})}%
 }{\end{enumerate}}
-\fi
 
 \ifthenelse{
   \equal{\doclicense@hyphenation}{}

--- a/doclicense/doclicense.sty
+++ b/doclicense/doclicense.sty
@@ -15,6 +15,7 @@
 \DeclareStringOption[10em]{imagewidth}
 \DeclareStringOption[2em]{imagedistance}
 \DeclareStringOption{hyphenation}
+\DeclareBoolOption[true]{enumitem}
 %% )))
 
 \ProcessLocalKeyvalOptions*
@@ -24,8 +25,12 @@
 \RequirePackage{etoolbox} %% \ifcsdef
 \RequirePackage{xspace}
 \RequirePackage{verbatim}
-\RequirePackage{enumitem}
 
+%% Use enumitem only if the beamer class is not loaded,
+%% as beamer and enumitem are incompatible
+\@ifclassloaded{beamer}{\doclicense@enumitemfalse}{}
+\ifdoclicense@enumitem
+\RequirePackage{enumitem}
 %% \setlistdepth{4} seems not to be needed. Try without it to avoid changing global variables.
 %% Enumeration scheme was chosen to match the html page once.
 \newlist{doclicense@enumerate}{enumerate}{4}
@@ -33,6 +38,10 @@
 \setlist[doclicense@enumerate,2]{label = (\arabic*)}
 \setlist[doclicense@enumerate,3]{label = (\Alph*)}
 \setlist[doclicense@enumerate,4]{label = (\roman*)}
+\else
+\let\doclicense@enumerate\enumerate
+\let\enddoclicense@enumerate\endenumerate
+\fi
 
 \ifthenelse{
   \equal{\doclicense@hyphenation}{}

--- a/doclicense/doclicense.sty
+++ b/doclicense/doclicense.sty
@@ -39,8 +39,13 @@
 \setlist[doclicense@enumerate,3]{label = (\Alph*)}
 \setlist[doclicense@enumerate,4]{label = (\roman*)}
 \else
-\let\doclicense@enumerate\enumerate
-\let\enddoclicense@enumerate\endenumerate
+\newenvironment{doclicense@enumerate}{%
+\begin{enumerate}
+\renewcommand{\labelenumi}{(\alph{enumi})}%
+\renewcommand{\labelenumii}{(\arabic{enumii})}%
+\renewcommand{\labelenumiii}{(\Alph{enumiii})}%
+\renewcommand{\labelenumiv}{(\roman{enumiv})}%
+}{\end{enumerate}}
 \fi
 
 \ifthenelse{


### PR DESCRIPTION
Don't load it when beamer class is used.

Provide opt-out option to not load it in other cases.

Fixes https://github.com/ypid/latex-packages/issues/40