### PR TITLE
Improve catalan long license text

### DIFF
--- a/doclicense/doclicense-catalan.ldf
+++ b/doclicense/doclicense-catalan.ldf
@@ -1,6 +1,6 @@
 \ProvidesFile{doclicense-catalan.ldf}
 
-\@namedef{doclicense@lang@thisDoc}{Aquesta obra està sota una llicència}%
+\@namedef{doclicense@lang@thisDoc}{Aquesta obra està subjecta a una llicència de}%
 \@namedef{doclicense@lang@word@license}{}%
 
 \@namedef{doclicense@lang@lic@CC@code}{ca}%


### PR DESCRIPTION
Adjust long license text according to which is been offered in the [creative commons web page](https://creativecommons.org/choose/?lang=ca) for the Catalan language

![Screenshot_2020-02-29 Choose a License](https://user-images.githubusercontent.com/38757307/75597343-3d1a9280-5a95-11ea-876f-28bf06ff61c2.png)