### PR TITLE
doclicense: Update ES translations

### DIFF
--- a/doclicense/doclicense-spanish.ldf
+++ b/doclicense/doclicense-spanish.ldf
@@ -15,16 +15,16 @@
 
 \@namedef{doclicense@lang@lic@CC@zero@1.0}{CC0 1.0 Universal}%
 
-\@namedef{doclicense@lang@lic@CC@by@3.0}{Reconocimiento 3.0 España}%
-\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{Reconocimiento-CompartirIgual 3.0 España}%
-\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{Reconocimiento-SinObraDerivada 3.0 España}%
-\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{Reconocimiento-NoCommercial 3.0 España}%
-\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{Reconocimiento-NoCommercial-CompartirIgual 3.0 España}%
-\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{Reconocimiento-NoCommercial-NoDerivs 3.0 España}%
+\@namedef{doclicense@lang@lic@CC@by@3.0}{Atribución 3.0 No portada}%
+\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{Atribución-CompartirIgual 3.0 No portada}%
+\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{Atribución-SinDerivadas 3.0 No portada}%
+\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{Atribución-NoComercial 3.0 No portada}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{Atribución-NoComercial-CompartirIgual 3.0 No portada}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{Atribución-NoComercial-SinDerivadas 3.0 No portada}%
 
-\@namedef{doclicense@lang@lic@CC@by@4.0}{Reconocimiento 4.0 Internacional}%
-\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{Reconocimiento-CompartirIgual 4.0 Internacional}%
-\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{Reconocimiento-SinObraDerivada 4.0 Internacional}%
-\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{Reconocimiento-NoCommercial 4.0 Internacional}%
-\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{Reconocimiento-NoCommercial-CompartirIgual 4.0 Internacional}%
-\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Reconocimiento-NoCommercial-SinObraDerivada 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by@4.0}{Atribución 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{Atribución-CompartirIgual 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{Atribución-SinDerivadas 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{Atribución-NoComercial 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{Atribución-NoComercial-CompartirIgual 4.0 Internacional}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Atribución-NoComercial-SinDerivadas 4.0 Internacional}%


### PR DESCRIPTION
It now matches the translations used in <https://creativecommons.org>.