### PR TITLE
chore(doclicense): Do not try to load hyperxmp if silence is loaded

### DIFF
--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -136,7 +136,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \printdateTeX{\filed
 % \changes{2.2.0}{2020/09/18}{Add Japanese and Bulgarian translation. Add hint how to use Chinese to docs. Load hyperxmp by default when it is installed. Before, doclicense just suggested to load it and made use of the package when the user did.}
 % \changes{2.2.1}{2020/09/25}{Fix compatibility issue with newer versions of hyperxmp (bug confirmed with Tex Live 2020) resulting in an compile error by loading hyperxmp and hyperref in the order the packages expect it.}
 % \changes{2.3.0}{2021/03/13}{Add option to disable the use of hyperxmp and add compatibility for pdfx. Use \url{https://reuse.software/} for the doclicense source code itself.}
-% \changes{2.4.0}{2021/XX/XX}{Add Croatian translation. Add sections about choosing a license and the REUSE specification. Update Spanish translation to match Creative Commons website. Add note to README that CC license texts and images are licensed themselves under CC0-1.0. Load csquotes after hyperref to avoid hyperref warning.} % Add a short note to CTAN maintainers when uploading: "Please consider the changed license statement in README.md"
+% \changes{2.4.0}{2021/XX/XX}{Add Croatian translation. Add sections about choosing a license and the REUSE specification. Update Spanish translation to match Creative Commons website. Add note to README that CC license texts and images are licensed themselves under CC0-1.0. Load csquotes after hyperref to avoid hyperref warning. Do not load the hyperxmp package if the silence package is loaded to avoid a endless loop.} % Add a short note to CTAN maintainers when uploading: "Please consider the changed license statement in README.md"
 %
 %
 
@@ -672,17 +672,28 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \printdateTeX{\filed
 \ifdoclicense@hyperxmp
   \@ifpackageloaded{pdfx}{%
     \PackageWarning{doclicense}{%
-    The pdfx package was detected. Therefore the mechanism to add license
-    metadata won't work. Ensure to setup \string\Copyright\space%
-    and corresponding settings to your xmpdata-file.
+      The pdfx package was detected. Therefore the mechanism to add license
+      metadata won't work. Ensure to setup \string\Copyright\space%
+      and corresponding settings to your xmpdata-file.
   }
   }{%
-    \IfFileExists{hyperxmp.sty}{%
-      \@ifpackageloaded{hyperxmp}{}{\RequirePackage{hyperxmp}}
-    }{%
+    \@ifpackageloaded{silence}{%
       \PackageWarning{doclicense}{%
-        The hyperxmp package is missing so no license metadata can be embedded
-        into the PDF. Consider installing hyperxmp.% chktex 13
+        The silence package was detected. hyperxmp and silence are not
+        compatible with each other so doclicense will not load hyperxmp as long
+        as you load silence. Therefore the mechanism to add license metadata
+        won't work.  Consider to compile the final version of your document
+        without silence so that you can benefit from hyperxmp while still being
+        able to filter log messages for your draft versions.
+      }
+    }{%
+      \IfFileExists{hyperxmp.sty}{%
+        \@ifpackageloaded{hyperxmp}{}{\RequirePackage{hyperxmp}}
+      }{%
+        \PackageWarning{doclicense}{%
+          The hyperxmp package is missing so no license metadata can be embedded
+          into the PDF. Consider installing hyperxmp.% chktex 13
+        }
       }
     }
   }


### PR DESCRIPTION
I am not keen to fix this in doclicense. But the facts that it worked before (because we did not load hyperxmp by default) and the fact that this is some sort of endless loop that could otherwise be hard to debug and waste CPU time and therefore resources, I decided to catch this case.

Closes: #78