### PR TITLE
Add Traditional Chinese (Taiwan) translation

### DIFF
--- a/doclicense/doclicense-chinese-tw.ldf
+++ b/doclicense/doclicense-chinese-tw.ldf
@@ -1,0 +1,30 @@
+% SPDX-FileCopyrightText: 2019 sd44 <sd44sd44@yeah.net>
+%
+% SPDX-License-Identifier: LPPL-1.3c
+%
+% This work consists of all files listed in manifest.txt.
+% For more details about the licensing, refer to the README.md file.
+
+\ProvidesFile{doclicense-chinese.ldf}
+
+\@namedef{doclicense@lang@thisDoc}{本作品以}%
+\@namedef{doclicense@lang@word@license}{公眾授權條款釋出}%
+
+\@namedef{doclicense@lang@lic@CC@code}{zh}%
+% Using:https://en.wikipedia.org/wiki/ISO_639-1
+
+\@namedef{doclicense@lang@lic@CC@zero@1.0}{CC0 1.0 通用}%
+
+\@namedef{doclicense@lang@lic@CC@by@3.0}{姓名標示 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{姓名標示-相同方式分享 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{姓名標示-禁止改作 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{姓名標示-非商業性 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{姓名標示-非商業性-相同方式分享 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{姓名標示-非商業性-禁止改作 3.0 台灣}%
+
+\@namedef{doclicense@lang@lic@CC@by@4.0}{姓名標示 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{姓名標示-相同方式分享 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{姓名標示-禁止改作 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{姓名標示-非商業性 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{姓名標示-非商業性-相同方式分享 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{姓名標示-非商業性-禁止改作 4.0 國際}%

--- a/doclicense/doclicense-chinese-tw.ldf
+++ b/doclicense/doclicense-chinese-tw.ldf
@@ -16,15 +16,15 @@
 \@namedef{doclicense@lang@lic@CC@zero@1.0}{CC0 1.0 通用}%
 
 \@namedef{doclicense@lang@lic@CC@by@3.0}{姓名標示 3.0 台灣}%
-\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{姓名標示-相同方式分享 3.0 台灣}%
-\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{姓名標示-禁止改作 3.0 台灣}%
-\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{姓名標示-非商業性 3.0 台灣}%
-\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{姓名標示-非商業性-相同方式分享 3.0 台灣}%
-\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{姓名標示-非商業性-禁止改作 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{姓名標示—相同方式分享 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{姓名標示—禁止改作 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{姓名標示—非商業性 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{姓名標示—非商業性—相同方式分享 3.0 台灣}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{姓名標示—非商業性—禁止改作 3.0 台灣}%
 
 \@namedef{doclicense@lang@lic@CC@by@4.0}{姓名標示 4.0 國際}%
-\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{姓名標示-相同方式分享 4.0 國際}%
-\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{姓名標示-禁止改作 4.0 國際}%
-\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{姓名標示-非商業性 4.0 國際}%
-\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{姓名標示-非商業性-相同方式分享 4.0 國際}%
-\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{姓名標示-非商業性-禁止改作 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{姓名標示—相同方式分享 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{姓名標示—禁止改作 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{姓名標示—非商業性 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{姓名標示—非商業性—相同方式分享 4.0 國際}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{姓名標示—非商業性—禁止改作 4.0 國際}%

--- a/doclicense/doclicense.dtx
+++ b/doclicense/doclicense.dtx
@@ -273,7 +273,7 @@ corresponds to \PackageName\nobreakspace\fileversion, dated \printdateTeX{\filed
 %   \item Brazilian
 %   \item Bulgarian
 %   \item Catalan
-%   \item Chinese: Note that you might need to pass \verb+lang={chinese-utf8}+ or \verb+chinese-gbk+.
+%   \item Chinese: Note that you might need to pass \verb+lang={chinese-utf8}+ \verb+lang={chinese-tw}+, or \verb+chinese-gbk+.
 %   \item Croatian
 %   \item English
 %   \item French

--- a/doclicense/manifest.txt
+++ b/doclicense/manifest.txt
@@ -16,6 +16,7 @@ doclicense/doclicense-canadian.ldf
 doclicense/doclicense-canadien.ldf
 doclicense/doclicense-catalan.ldf
 doclicense/doclicense-chinese-gbk.ldf
+doclicense/doclicense-chinese-tw.ldf
 doclicense/doclicense-chinese-utf8.ldf
 doclicense/doclicense-croatian.ldf
 doclicense/doclicense.dtx


### PR DESCRIPTION
The translation can be invoked by option lang={chinese-tw} and it is adopted from Creative Commons
https://creativecommons.org/licenses/by-nc-nd/3.0/tw/deed.zh_TW
https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode.zh-Hant
