### PR TITLE
Add PDF/A conversion for pdf images using Ghostscript.

### DIFF
--- a/doclicense/doclicense-finnish.ldf
+++ b/doclicense/doclicense-finnish.ldf
@@ -1,0 +1,32 @@
+% SPDX-FileCopyrightText: 2025 Luis R.J. Costa
+% SPDX-FileCopyrightText: 2025 Pekka Pietikäinen
+%
+% SPDX-License-Identifier: LPPL-1.3c OR CC-BY-SA-4.0
+%
+% This work consists of all files listed in manifest.txt.
+% For more details about the licensing, refer to the README.md file.
+
+\ProvidesFile{doclicense-finnish.ldf}
+
+\@namedef{doclicense@lang@thisDoc}{Tämä teos on lisensoitu}%
+\@namedef{doclicense@lang@word@license}{ -käyttöluvalla}%
+%
+\@namedef{doclicense@lang@lic@CC@code}{fi}%
+% Using: https://en.wikipedia.org/wiki/ISO_639-1
+%
+\@namedef{doclicense@lang@lic@CC@zero@1.0}{CC0 1.0 Yleismaailmallinen}%
+%
+\@namedef{doclicense@lang@lic@CC@by@3.0}{Nimeä 3.0 Ei sovitettu}%
+\@namedef{doclicense@lang@lic@CC@by-sa@3.0}{Nimeä-JaaSamoin 3.0 Ei sovitettu}%
+\@namedef{doclicense@lang@lic@CC@by-nd@3.0}{Nimeä-EiMuutoksia 3.0 Ei sovitettu}%
+\@namedef{doclicense@lang@lic@CC@by-nc@3.0}{Nimeä-EiKaupallinen 3.0 Ei sovitettu}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@3.0}{Nimeä-EiKaupallinen-JaaSamoin 3.0 Ei sovitettu}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@3.0}{Nimeä-EiKaupallinen-EiMuutoksia 3.0 Ei sovitettu}%
+%
+\@namedef{doclicense@lang@lic@CC@by@4.0}{Nimeä 4.0 Kansainvälinen}%
+\@namedef{doclicense@lang@lic@CC@by-sa@4.0}{Nimeä-JaaSamoin 4.0 Kansainvälinen}%
+\@namedef{doclicense@lang@lic@CC@by-nd@4.0}{Nimeä-EiMuutoksia 4.0 Kansainvälinen}%
+\@namedef{doclicense@lang@lic@CC@by-nc@4.0}{Nimeä-EiKaupallinen 4.0 Kansainvälinen}%
+\@namedef{doclicense@lang@lic@CC@by-nc-sa@4.0}{Nimeä-EiKaupallinen-JaaSamoin 4.0 Kansainvälinen}%
+\@namedef{doclicense@lang@lic@CC@by-nc-nd@4.0}{Nimeä-EiKaupallinen-EiMuutoksia 4.0 Kansainvälinen}%
+

--- a/doclicense/images/Makefile
+++ b/doclicense/images/Makefile
@@ -72,7 +72,10 @@ doclicense-CC-%.svg:
 
 %.pdf: %.svg
 	@# For Inkscape 0.x: inkscape "$<" --export-pdf "$@"
-	inkscape "$<" --export-type=pdf --export-filename "$@"
+	inkscape "$<" --export-type=pdf --export-filename "$@.tmp.pdf"
+	@# Convert to PDF/A
+	gs -dPDFA -dBATCH -dNOPAUSE -sColorConversionStrategy=UseDeviceIndependentColor -sDEVICE=pdfwrite -dPDFACompatibilityPolicy=2 -sOutputFile="$@" "$@.tmp.pdf"
+	rm -f "$@.tmp.pdf"
 
 	@# Make output deterministic:
 	sed --regexp-extended --in-place "s#^(.*/CreationDate \()D:[0-9+')]+\)#\1D:20200523232323+02'00)#;" "$@"

--- a/doclicense/test-package-option-matrix
+++ b/doclicense/test-package-option-matrix
@@ -20,7 +20,7 @@ function main() {
     echo "$supported_licenses" | \
         while read -r type modifier version; do
         for imagemodifier in "" "-eu" "-80x15"; do
-            for lang in "ngerman" "english" "brazilian" "spanish" "french" "russian" "italian" "polish" "portuguese" "catalan" "galician" "croatian" "swedish" "esperanto" "ukrainian" "austrian" "naustrian" "swissgerman" "nswissgerman" "greek"; do
+            for lang in "ngerman" "english" "brazilian" "spanish" "french" "russian" "italian" "polish" "portuguese" "catalan" "galician" "croatian" "swedish" "esperanto" "ukrainian" "austrian" "naustrian" "swissgerman" "nswissgerman" "greek" "finnish"; do
                 if [ "$lang" == "ngerman" ] && [ "$modifier" == "pd" ]; then
                     continue # Does not exist in Germany.
                 fi


### PR DESCRIPTION
Tested with Inkscape 1.4.2 (ebf0e940d0, 2025-05-08), Pango 1.56.3 and Ghostscript 10.05.0. Command line options for PDF/A seem to vary between different Ghostscript versions.

Outputs validated with VeraPDF 1.26.4 with -f 1b option.

Fixes #114